### PR TITLE
Feature: Export Mudlet compatible JSON map

### DIFF
--- a/export.js
+++ b/export.js
@@ -1,6 +1,7 @@
 module.exports = {
     MudletMapReader : {
         read: require("./map-reader"),
-        export: require("./reader-export")
+        export: require("./reader-export"),
+        exportJson: require('./json-export')
     }
 };

--- a/json-export.js
+++ b/json-export.js
@@ -191,7 +191,7 @@ const convertStubExits = (stubs, doors) => {
     const stub = {
       name: direction,
       door:
-        room.doors[direction] !== undefined
+        doors[direction] !== undefined
           ? doorMap[doors[direction]]
           : undefined,
     };

--- a/json-export.js
+++ b/json-export.js
@@ -224,7 +224,7 @@ const chunkString = (str, length) => {
 const addMapStatistics = (map, convertedObject) => {
   convertedObject.areaCount = Object.keys(map.areas).length;
   convertedObject.roomCount = Object.keys(map.rooms).length;
-  convertedObject.labelCount = Object.keys(map.labels).length;
+  convertedObject.labelCount = _.flatMap(map.labels, (label) => label).length;
 };
 
 // currently not in the binary map

--- a/json-export.js
+++ b/json-export.js
@@ -1,0 +1,292 @@
+const fs = require('fs');
+const _ = require('lodash');
+
+const directions = [
+  'north',
+  'northeast',
+  'northwest',
+  'east',
+  'west',
+  'south',
+  'southeast',
+  'southwest',
+  'up',
+  'down',
+  'in',
+  'out',
+];
+const directionShortNames = [
+  'n',
+  'ne',
+  'nw',
+  'e',
+  'w',
+  's',
+  'se',
+  'sw',
+  'up',
+  'down',
+  'in',
+  'out',
+];
+const doorMap = [undefined, 'open', 'closed', 'locked'];
+
+const exportMap = (map, mapFile, minified) => {
+  const mudletMap = convertMapToMudletFormat(map);
+
+  const mapJson = JSON.stringify(mudletMap, null, minified ? 0 : 2);
+
+  fs.writeFileSync(mapFile, mapJson);
+};
+
+const convertMapToMudletFormat = (map) => {
+  const convertedObject = {
+    formatVersion: 1.0,
+  };
+
+  convertUserData(map, convertedObject);
+  convertAreas(map, convertedObject);
+  addMapStatistics(map, convertedObject);
+  addDefaultAreaName(map, convertedObject);
+  addAnonymousAreaName(map, convertedObject);
+  convertEnvironmentColors(map, convertedObject);
+  convertPlayerRooms(map, convertedObject);
+  convertCustomEnvironmentColours(map, convertedObject);
+  convertMapSymbolInfo(map, convertedObject);
+  convertPlayerRoomLook(map, convertedObject);
+
+  return convertedObject;
+};
+
+const convertUserData = (map, convertedObject) => {
+  convertedObject.userData = map.userData;
+};
+
+const convertAreas = (map, convertedObject) => {
+  const convertedAreas = _.map(map.areas, (area) => convertArea(area, map));
+  convertedObject.areas = convertedAreas;
+};
+
+const convertArea = (area, map) => {
+  const convertedArea = {
+    id: area.id,
+    name: map.areaNames[area.id] || '',
+    gridMode: area.gridMode ? true : undefined,
+    roomCount: area.rooms.length,
+    rooms: _.map(area.rooms, (roomId) => convertRoom(roomId, map)),
+  };
+  if (!_.isEmpty(area.userData)) {
+    convertedArea.userData = area.userData;
+  }
+  if (!_.isEmpty(map.labels[area.id])) {
+    convertedArea.labels = _.map(map.labels[area.id], convertLabel);
+  }
+  return convertedArea;
+};
+
+const convertRoom = (roomId, map) => {
+  const room = map.rooms[roomId];
+  const convertedRoom = {
+    id: room.id,
+    name: room.name !== '' ? room.name : undefined,
+    coordinates: [room.x, room.y, room.z],
+    locked: room.isLocked ? true : undefined,
+    weight: room.weight !== 1 ? room.weight : undefined,
+    symbol: room.symbol !== '' ? { text: room.symbol } : undefined, //binary map does not seem to support symbol colours
+    environment: room.environment,
+    hash: room.hash,
+    exits: [],
+    stubExits: convertStubExits(room.stubs, room.doors),
+    userData: _.isEmpty(room.userData) ? undefined : room.userData,
+  };
+
+  for (let i = 0; i < directions.length; i++) {
+    const direction = directions[i];
+    const shortDirection = directionShortNames[i];
+    if (room[direction] !== -1) {
+      convertedRoom.exits.push({
+        exitId: room[direction],
+        name: direction,
+        weight: getExitWeight(shortDirection, room.exitWeights, 1),
+        locked: _.find(room.exitLocks, (num) => i === num - 1)
+          ? true
+          : undefined,
+        door:
+          room.doors[shortDirection] !== undefined
+            ? doorMap[room.doors[shortDirection]]
+            : undefined,
+        customLine: convertCustomLine(
+          room.customLines[shortDirection],
+          room.customLinesArrow[shortDirection],
+          room.customLinesColor[shortDirection],
+          room.customLinesStyle[shortDirection]
+        ),
+      });
+    }
+  }
+  for (const specialExit in room.mSpecialExits) {
+    convertedRoom.exits.push({
+      name: specialExit,
+      exitId: room.mSpecialExits[specialExit],
+      weight: getExitWeight(specialExit, room.exitWeights, 1),
+      locked: _.find(
+        room.mSpecialExitLocks,
+        (exitCommand) => specialExit === exitCommand
+      )
+        ? true
+        : undefined,
+      door:
+        room.doors[specialExit] !== undefined
+          ? doorMap[room.doors[specialExit]]
+          : undefined,
+      customLine: convertCustomLine(
+        room.customLines[specialExit],
+        room.customLinesArrow[specialExit],
+        room.customLinesColor[specialExit],
+        room.customLinesStyle[specialExit]
+      ),
+    });
+  }
+  return convertedRoom;
+};
+
+const getExitWeight = (direction, weights, defaultValue) => {
+  const weight = weights[direction];
+  if (weight === undefined || weight === defaultValue) {
+    return undefined;
+  }
+  return weight;
+};
+
+const convertCustomLine = (coordinates, arrow, color, style) => {
+  if (coordinates === undefined || _.isEmpty(coordinates)) {
+    return undefined;
+  }
+  // use the color object as base as we don't have a nesting in this case
+  const line = convertColor(color);
+  line.coordinates = coordinates;
+  line.endsInArrow = arrow;
+  line.style = convertLineStyle(style);
+  return line;
+};
+
+const lineStyles = {
+  2: 'dash line',
+  3: 'dot line',
+  4: 'dash dot line',
+  5: 'dash dot dot line',
+};
+
+const convertLineStyle = (style) => {
+  return lineStyles[style];
+};
+
+const convertStubExits = (stubs, doors) => {
+  if (stubs.length === 0) {
+    return undefined;
+  }
+  const convertedStubs = [];
+  for (const dirNum of stubs) {
+    const direction = directions[dirNum];
+    const stub = {
+      name: direction,
+      door:
+        room.doors[direction] !== undefined
+          ? doorMap[doors[direction]]
+          : undefined,
+    };
+    convertedStubs.push(stub);
+  }
+  return stubs;
+};
+
+const convertLabel = (label) => {
+  return {
+    colors: [convertColor(label.fgColor), convertColor(label.bgColor)],
+    coordinates: [label.pos[0], label.pos[1], label.pos[2]],
+    id: label.labelId,
+    image: chunkString(Buffer.from(label.pixMap).toString('base64'), 64), // not the same base64 string as in Mudlet's JSON, but should yield the same result
+    scaledels: !label.noScaling,
+    showOnTop: label.showOnTop,
+    text: label.text,
+    size: [label.size[0], label.size[1]],
+  };
+};
+
+const chunkString = (str, length) => {
+  return str.match(new RegExp(`.{1,${length}}`, 'g'));
+};
+
+const addMapStatistics = (map, convertedObject) => {
+  convertedObject.areaCount = Object.keys(map.areas).length;
+  convertedObject.roomCount = Object.keys(map.rooms).length;
+  convertedObject.labelCount = Object.keys(map.labels).length;
+};
+
+// currently not in the binary map
+const addDefaultAreaName = (_map, convertedObject) => {
+  convertedObject.defaultAreaName = 'Default Area';
+};
+
+// currently not in the binary map
+const addAnonymousAreaName = (_map, convertedObject) => {
+  convertedObject.anonymousAreaName = 'Unnamed Area';
+};
+
+const convertEnvironmentColors = (map, convertedObject) => {
+  convertedObject.envToColorMapping = map.envColors;
+};
+
+const convertPlayerRooms = (map, convertedObject) => {
+  convertedObject.playersRoomId = map.roomIdHash;
+};
+
+const convertCustomEnvironmentColours = (map, convertedObject) => {
+  const colors = _.map(map.customEnvColors, (color, index) => {
+    const convertedColor = convertColor(color);
+    convertedColor.id = parseInt(index);
+    return convertedColor;
+  });
+  convertedObject.customEnvColors = colors;
+};
+
+const convertColor = (color) => {
+  const ret = {};
+  const colorArray = [color.r, color.g, color.b];
+  if (color.alpha < 255) {
+    colorArray.push(color.alpha);
+    ret.color32RGBA = colorArray;
+  } else {
+    ret.color24RGB = colorArray;
+  }
+  return ret;
+};
+
+const convertMapSymbolInfo = (map, convertedObject) => {
+  const f = map.mapSymbolFont;
+  // the string produced by the QFont source does not seem to match the one in the QFont::toString() documentation as it's missing some values
+  // However, the source code string seems to match what is in our JSON so we reproduce that.
+  const fontString = `${f.family},${f.pointSize},${f.pixelSize},${
+    f.styleHint
+  },${f.weight},${f.styleSetting ? 1 : 0},${f.underline ? 1 : 0},${
+    f.strikeOut ? 1 : 0
+  },${f.fixedPitch ? 1 : 0},0`;
+
+  convertedObject.mapSymbolFontDetails = fontString;
+  convertedObject.mapSymbolFontFudgeFactor = map.mapFontFudgeFactor;
+  convertedObject.onlyMapSymbolFontToBeUsed = map.useOnlyMapFont;
+};
+
+const convertPlayerRoomLook = (_map, convertedObject) => {
+  // not part of the binary map... These are some kind of setting, why are they even part of the JSON map?
+  // so use a fixed value
+  convertedObject.playerRoomColors = [
+    { color24RGB: [255, 0, 0] },
+    { color24RGB: [255, 255, 255] },
+  ];
+  convertedObject.playerRoomInnerDiameterPercentage = 70;
+  convertedObject.playerRoomOuterDiameterPercentage = 120;
+  convertedObject.playerRoomStyle = 0;
+};
+
+module.exports = exportMap;

--- a/json-export.js
+++ b/json-export.js
@@ -267,13 +267,16 @@ const convertColor = (color) => {
 
 const convertMapSymbolInfo = (map, convertedObject) => {
   const f = map.mapSymbolFont;
+  const firstFamilyComma = f.family.indexOf(',');
+  const family =
+    firstFamilyComma > -1 ? f.family.substr(0, firstFamilyComma) : f.family;
   // the string produced by the QFont source does not seem to match the one in the QFont::toString() documentation as it's missing some values
   // However, the source code string seems to match what is in our JSON so we reproduce that.
-  const fontString = `${f.family},${f.pointSize},${f.pixelSize},${
-    f.styleHint
-  },${f.weight},${f.styleSetting ? 1 : 0},${f.underline ? 1 : 0},${
-    f.strikeOut ? 1 : 0
-  },${f.fixedPitch ? 1 : 0},0`;
+  const fontString = `${family},${f.pointSize},${f.pixelSize},${f.styleHint},${
+    f.weight
+  },${f.styleSetting ? 1 : 0},${f.underline ? 1 : 0},${f.strikeOut ? 1 : 0},${
+    f.fixedPitch ? 1 : 0
+  },0`;
 
   convertedObject.mapSymbolFontDetails = fontString;
   convertedObject.mapSymbolFontFudgeFactor = map.mapFontFudgeFactor;

--- a/json-export.js
+++ b/json-export.js
@@ -201,8 +201,6 @@ const convertStubExits = (stubs, doors) => {
     };
     convertedStubs.push(stub);
   }
-  console.log(stubs)
-  console.log(convertedStubs)
   return convertedStubs;
 };
 

--- a/json-export.js
+++ b/json-export.js
@@ -187,17 +187,20 @@ const convertStubExits = (stubs, doors) => {
   }
   const convertedStubs = [];
   for (const dirNum of stubs) {
-    const direction = directions[dirNum];
+    const direction = directions[dirNum - 1];
+    const shortDirection = directionShortNames[dirNum - 1];
     const stub = {
       name: direction,
       door:
-        doors[direction] !== undefined
-          ? doorMap[doors[direction]]
+        doors[shortDirection] !== undefined
+          ? doorMap[doors[shortDirection]]
           : undefined,
     };
     convertedStubs.push(stub);
   }
-  return stubs;
+  console.log(stubs)
+  console.log(convertedStubs)
+  return convertedStubs;
 };
 
 const convertLabel = (label) => {

--- a/json-export.js
+++ b/json-export.js
@@ -59,6 +59,9 @@ const convertMapToMudletFormat = (map) => {
 };
 
 const convertUserData = (map, convertedObject) => {
+  if (_.isEmpty(map.userData)) {
+    return;
+  }
   convertedObject.userData = map.userData;
 };
 

--- a/map-reader.js
+++ b/map-reader.js
@@ -1,4 +1,4 @@
-const { QMap, QBool, QInt, QDouble, QUInt, QString, QShort } = require("qtdatastream").types;
+const { QBool, QInt, QDouble, QUInt, QString, QStringList, QMap } = require("qtdatastream").types;
 const { ReadBuffer } = require("qtdatastream").buffer;
 const fs = require("fs");
 
@@ -14,12 +14,44 @@ function readQColor(buffer) {
 }
 
 function readQFont(buffer) {
-  let font = {
-    family: QString.read(buffer),
-    style: QString.read(buffer),
-    pointSize: QDouble.read(buffer),
+  const family = QString.read(buffer);
+  const style = QString.read(buffer);
+  const pointSize = QDouble.read(buffer);
+  const pixelSize = QInt.read(buffer);
+  const styleHint = buffer.readInt8() >>> 0;
+  const styleStrategy = buffer.readUInt16BE() >> 8;
+  buffer.readInt8();
+  const weight = buffer.readInt8()>>>0;
+  const fontBits = buffer.readInt8()>>>0;
+  const stretch = buffer.readUInt16BE();
+  const extendedFontBits = buffer.readInt8()>>>0;
+  const letterSpacing = QInt.read(buffer);
+  const wordSpacing = QInt.read(buffer);
+  const hintingPreference = buffer.readInt8()>>>0;
+  const capital = buffer.readInt8()>>>0;
+  //QFont source has this as well, but the binary map doesn't?
+  //const families = QStringList.read(buffer);
+  const fudgeFactor = QDouble.read(buffer);
+  const useOnlyMapFont =QBool.read(buffer);
+  const font = {
+    family,
+    style,
+    pointSize,
+    pixelSize,
+    styleHint,
+    styleStrategy,
+    weight,
+    fontBits,
+    stretch,
+    extendedFontBits,
+    letterSpacing,
+    wordSpacing,
+    hintingPreference,
+    capital,
+    //families,
+    fudgeFactor,
+    useOnlyMapFont
   };
-  buffer.read_offset += 32; // QFont deserialization ???
   return font;
 }
 

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "url": "git+https://github.com/Delwing/node-mudlet-map-binary-reader.git"
   },
   "dependencies": {
+    "lodash": "^4.17.21",
     "qtdatastream": "^1.1.0"
   },
   "exports": "./export.js",

--- a/yarn.lock
+++ b/yarn.lock
@@ -14,6 +14,11 @@ int64-buffer@^0.99.1007:
   resolved "https://registry.yarnpkg.com/int64-buffer/-/int64-buffer-0.99.1007.tgz#211ea089a2fdb960070a2e77cd6d17dc456a5220"
   integrity sha512-XDBEu44oSTqlvCSiOZ/0FoUkpWu/vwjJLGSKDabNISPQNZ5wub1FodGHBljRsrR0IXRPq7SslshZYMuA55CgTQ==
 
+lodash@^4.17.21:
+  version "4.17.21"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
+  integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
+
 ms@2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"


### PR DESCRIPTION
The map reader can now export maps in Mudlet's own JSON map format. I compared the output with the maps of Achaea, Imperian, Lusternia, Starmourn and Stickmud. They all produced the same semantic output. The only exception is the map label pixmap, which Mudlet compresses. But online tools suggested these pixmaps are actually equivalent.

Some data is not part of the binary map, so I used fixed data.