### PR TITLE
Fix the locking of special exits in JSON export

### DIFF
--- a/json-export.js
+++ b/json-export.js
@@ -136,7 +136,7 @@ const convertRoom = (roomId, map) => {
       weight: getExitWeight(specialExit, room.exitWeights, 1),
       locked: _.find(
         room.mSpecialExitLocks,
-        (exitCommand) => specialExit === exitCommand
+        (destinationRoom) => room.mSpecialExits[specialExit] === destinationRoom
       )
         ? true
         : undefined,


### PR DESCRIPTION
Currently, special exits in the JSON export are not properly locked due to a bug in the interpretation of what the array `mSpecialExitLocks` actually contains.

Additionally, I noticed a conceptual issue with this array (which is not fixed): if there are multiple special exits from a room to another, they can not be locked separately as the array can not distinguish between the exits.