### PR TITLE
Add read-only support for Mudlet map versions 16-19

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## Project overview
 
-Node.js library for reading and writing Mudlet's binary map files (v20 format). Parses Qt QDataStream-serialized data into typed TypeScript models. Can export maps to JSON or to JS files for Mudlet Map Reader.
+Node.js library for reading and writing Mudlet's binary map files (v20 format), with read-only support for the older v16–v19 formats. Parses Qt QDataStream-serialized data into typed TypeScript models. Can export maps to JSON or to JS files for Mudlet Map Reader.
 
 ## Package manager
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![NPM](https://nodei.co/npm/mudlet-map-binary-reader.png)](https://nodei.co/npm/mudlet-map-binary-reader/)
 
-Reads and writes Mudlet's map binary file (v20). Can also convert a map to the [JS Mudlet Map Renderer](https://github.com/Delwing/js-mudlet-map-renderer) format or to Mudlet's JSON format.
+Reads and writes Mudlet's map binary file (v20), and additionally reads the older formats v16–v19 (read-only). Can also convert a map to the [JS Mudlet Map Renderer](https://github.com/Delwing/js-mudlet-map-renderer) format or to Mudlet's JSON format.
 
 The library works with **bytes** and never touches the filesystem — you handle reading and writing files yourself.
 

--- a/src/models/legacy.ts
+++ b/src/models/legacy.ts
@@ -1,0 +1,354 @@
+import {
+  QBool,
+  QClass,
+  QUserType,
+  qtype,
+  QInt,
+  QUInt,
+  QDouble,
+} from 'qtdatastream-web/types';
+import type { ReadBuffer } from 'qtdatastream-web';
+import { registerBaseTypes, Types } from './base-types';
+import { createMudletLabels, createMudletRooms, createMudletAreas } from './mudlet-types';
+import { QList, QMap, QPair, QMultiMap } from './qstream-containers';
+import { QString, QColor, QPoint } from './qstream-types';
+import { registerMapModel } from './model-registry';
+import type { MudletColor, MudletFont, MudletMap } from '../types';
+
+// ---------------------------------------------------------------------------
+// Mudlet map formats, versions 16-19 (read-only).
+//
+// These older formats differ from v20 in a handful of fields. Rather than copy
+// the whole v20 module four times, this builder takes a per-version config of
+// the deltas and registers a read-only MapModel. The deltas mirror the
+// version-gated branches in Mudlet's C++ TMap::restore / TRoom::restore /
+// TArea operator>> exactly:
+//
+//   * mUserData (map-level)   : v17+         (absent in v16)
+//   * map symbol font fields  : v19+         (absent in v16-v18)
+//   * mRoomIdHash             : QMap in v18+, a single legacy int in v16-v17
+//   * area per-Z extent maps  : 4 maps in v17+, 6 (2 unused) in v16
+//   * area userData           : v17+         (absent in v16)
+//   * room.symbol             : QString in v19+, a single qint8 char in v16-v18
+//   * room.customLinesColor   : QColor in v20, QList<int> (RGB) in v16-v19
+//   * room.customLinesStyle   : QUInt in v20, QString style-name in v16-v19
+//
+// Writing these versions is intentionally unsupported: Mudlet only ever saves
+// the newest format, so a round-trip would have to be lossy. writeMap throws.
+// ---------------------------------------------------------------------------
+
+registerBaseTypes();
+
+// Qt pen styles, mirroring the QString -> Qt::PenStyle mapping in TRoom::restore
+// for pre-v20 maps. Values match Qt::PenStyle (SolidLine = 1 ... DashDotDotLine = 5).
+const PEN_STYLE: Record<string, number> = {
+  'dot line': 3,
+  'dash line': 2,
+  'dash dot line': 4,
+  'dash dot dot line': 5,
+};
+
+// A neutral default map symbol font for versions (v16-v18) that don't store one.
+// Mudlet itself falls back to extracting these from userData keys; we surface a
+// sane stand-in so downstream consumers (e.g. JSON export) always have a font.
+const DEFAULT_FONT: MudletFont = {
+  family: 'Bitstream Vera Sans Mono',
+  style: '',
+  pointSize: 10,
+  pixelSize: -1,
+  styleHint: 0,
+  styleStrategy: 0,
+  weight: 50,
+  fontBits: 0,
+  stretch: 0,
+  extendedFontBits: 0,
+  letterSpacing: 0,
+  wordSpacing: 0,
+  hintingPreference: 0,
+  capital: 0,
+  styleSetting: false,
+  underline: false,
+  overline: false,
+  strikeOut: false,
+  fixedPitch: true,
+  kerning: false,
+  styleOblique: false,
+  ignorePitch: false,
+  letterSpacingIsAbsolute: false,
+};
+
+/** Reads a v16-v18 room symbol: a single signed byte (Qt qint8 char code). */
+class QSymbolByte extends QClass {
+  static override read(buffer: ReadBuffer): string {
+    const code = buffer.readInt8();
+    // Mudlet keeps codes <= 32 (control/space) as "no symbol".
+    return code > 32 ? String.fromCodePoint(code) : '';
+  }
+
+  override toBuffer(): Uint8Array {
+    throw new Error('writing legacy Mudlet map versions is not supported');
+  }
+}
+
+/** Reads a pre-v20 custom-line colour: a QList<int> of [r, g, b] -> MudletColor. */
+class QColorFromIntList extends QClass {
+  static override read(buffer: ReadBuffer): MudletColor {
+    const count = QUInt.read(buffer);
+    const channels: number[] = [];
+    for (let i = 0; i < count; i++) {
+      channels.push(QInt.read(buffer));
+    }
+    // C++ only keeps lists with >= 3 entries; missing colours default to red.
+    if (channels.length >= 3) {
+      return { spec: 1, alpha: 255, r: channels[0], g: channels[1], b: channels[2], pad: 0 };
+    }
+    return { spec: 1, alpha: 255, r: 255, g: 0, b: 0, pad: 0 };
+  }
+
+  override toBuffer(): Uint8Array {
+    throw new Error('writing legacy Mudlet map versions is not supported');
+  }
+}
+
+/** Reads a pre-v20 custom-line style: a QString style-name -> Qt::PenStyle int. */
+class QStyleFromString extends QClass {
+  static override read(buffer: ReadBuffer): number {
+    const name = QString.read(buffer) as unknown as string;
+    return PEN_STYLE[name] ?? 1; // default Qt::SolidLine
+  }
+
+  override toBuffer(): Uint8Array {
+    throw new Error('writing legacy Mudlet map versions is not supported');
+  }
+}
+
+/**
+ * Reads the pre-v18 mRoomIdHash: a single legacy "current room" int. The
+ * profile name it was keyed by in C++ isn't in the stream, so the value can't
+ * be reattached meaningfully — we consume the int and surface an empty map.
+ */
+class QLegacyRoomId extends QClass {
+  static override read(buffer: ReadBuffer): Record<string, number> {
+    QInt.read(buffer);
+    return {};
+  }
+
+  override toBuffer(): Uint8Array {
+    throw new Error('writing legacy Mudlet map versions is not supported');
+  }
+}
+
+// Shared Qt type ids for the legacy-only value readers above. Registered once.
+const LEGACY_TYPE = {
+  SYMBOL_BYTE: 300,
+  COLOR_INTLIST: 301,
+  STYLE_STRING: 302,
+  ROOM_ID: 303,
+} as const;
+
+let legacyTypesRegistered = false;
+function registerLegacyValueTypes(): void {
+  if (legacyTypesRegistered) return;
+  legacyTypesRegistered = true;
+  qtype(LEGACY_TYPE.SYMBOL_BYTE)(QSymbolByte);
+  qtype(LEGACY_TYPE.COLOR_INTLIST)(QColorFromIntList);
+  qtype(LEGACY_TYPE.STYLE_STRING)(QStyleFromString);
+  qtype(LEGACY_TYPE.ROOM_ID)(QLegacyRoomId);
+}
+
+interface LegacyConfig {
+  /** Map-level user data exists (v17+). */
+  hasMapUserData: boolean;
+  /** Map symbol font / fudge factor / only-font flag exist (v19+). */
+  hasMapFont: boolean;
+  /** mRoomIdHash is a real QMap (v18+) vs a single legacy int (v16-v17). */
+  modernRoomIdHash: boolean;
+  /** Area stores 4 per-Z extent maps + userData (v17+) vs 6 maps, no userData (v16). */
+  modernArea: boolean;
+  /** room.symbol is a QString (v19+) vs a single qint8 char (v16-v18). */
+  stringSymbol: boolean;
+}
+
+const CONFIGS: Record<number, LegacyConfig> = {
+  16: { hasMapUserData: false, hasMapFont: false, modernRoomIdHash: false, modernArea: false, stringSymbol: false },
+  17: { hasMapUserData: true, hasMapFont: false, modernRoomIdHash: false, modernArea: true, stringSymbol: false },
+  18: { hasMapUserData: true, hasMapFont: false, modernRoomIdHash: true, modernArea: true, stringSymbol: false },
+  19: { hasMapUserData: true, hasMapFont: true, modernRoomIdHash: true, modernArea: true, stringSymbol: true },
+};
+
+/**
+ * Register a read-only MapModel for one of the legacy versions 16-19. Each
+ * version gets its own version-qualified QUserType names and Qt container ids
+ * so the global registry never clobbers another version (including v20).
+ */
+export function registerLegacyMapModel(version: number): void {
+  const cfg = CONFIGS[version];
+  if (!cfg) throw new Error(`No legacy config for Mudlet map version ${version}`);
+
+  registerLegacyValueTypes();
+
+  const TYPE = {
+    MAP: `MudletMap@${version}`,
+    AREA: `MudletArea@${version}`,
+    ROOM: `MudletRoom@${version}`,
+    LABEL: `MudletLabel@${version}`,
+  };
+
+  // Per-version Qt container ids (e.g. 160/161/162 for v16) so each version's
+  // label/room/area containers resolve their own nested version-qualified type.
+  const CONTAINER = {
+    LABELS: version * 10,
+    ROOMS: version * 10 + 1,
+    AREAS: version * 10 + 2,
+  };
+
+  qtype(CONTAINER.LABELS)(createMudletLabels(TYPE.LABEL));
+  qtype(CONTAINER.ROOMS)(createMudletRooms(TYPE.ROOM));
+  qtype(CONTAINER.AREAS)(createMudletAreas(TYPE.AREA));
+
+  // --- Area -------------------------------------------------------------
+  const areaFields: Record<string, number>[] = [
+    { rooms: QList(QUInt) },
+    { zLevels: QList(QInt) },
+    { mAreaExits: QMultiMap(QInt, QPair(QInt, QInt)) },
+    { gridMode: Types.BOOL },
+    { max_x: Types.INT },
+    { max_y: Types.INT },
+    { max_z: Types.INT },
+    { min_x: Types.INT },
+    { min_y: Types.INT },
+    { min_z: Types.INT },
+    { span: Types.VECTOR },
+  ];
+  if (cfg.modernArea) {
+    areaFields.push(
+      { xmaxForZ: QMap(QInt, QInt) },
+      { ymaxForZ: QMap(QInt, QInt) },
+      { xminForZ: QMap(QInt, QInt) },
+      { yminForZ: QMap(QInt, QInt) }
+    );
+  } else {
+    // v16 interleaves two unused QMap<int,int> blocks between the extents.
+    areaFields.push(
+      { xmaxForZ: QMap(QInt, QInt) },
+      { ymaxForZ: QMap(QInt, QInt) },
+      { legacyForZUnused1: QMap(QInt, QInt) },
+      { xminForZ: QMap(QInt, QInt) },
+      { yminForZ: QMap(QInt, QInt) },
+      { legacyForZUnused2: QMap(QInt, QInt) }
+    );
+  }
+  areaFields.push({ pos: Types.VECTOR }, { isZone: Types.BOOL }, { zoneAreaRef: Types.INT });
+  if (cfg.modernArea) {
+    areaFields.push({ userData: QMap(QString, QString) });
+  }
+  QUserType.register(TYPE.AREA, areaFields);
+
+  // --- Room -------------------------------------------------------------
+  QUserType.register(TYPE.ROOM, [
+    { area: Types.INT },
+    { x: Types.INT },
+    { y: Types.INT },
+    { z: Types.INT },
+    { north: Types.INT },
+    { northeast: Types.INT },
+    { east: Types.INT },
+    { southeast: Types.INT },
+    { south: Types.INT },
+    { southwest: Types.INT },
+    { west: Types.INT },
+    { northwest: Types.INT },
+    { up: Types.INT },
+    { down: Types.INT },
+    { in: Types.INT },
+    { out: Types.INT },
+    { environment: Types.INT },
+    { weight: Types.INT },
+    { name: Types.STRING },
+    { isLocked: Types.BOOL },
+    { rawSpecialExits: QMultiMap(QUInt, QString) },
+    { symbol: cfg.stringSymbol ? Types.STRING : LEGACY_TYPE.SYMBOL_BYTE },
+    { userData: QMap(QString, QString) },
+    { customLines: QMap(QString, QList(QPoint)) },
+    { customLinesArrow: QMap(QString, QBool) },
+    { customLinesColor: QMap(QString, QColorFromIntList) },
+    { customLinesStyle: QMap(QString, QStyleFromString) },
+    { exitLocks: QList(QInt) },
+    { stubs: QList(QInt) },
+    { exitWeights: QMap(QString, QInt) },
+    { doors: QMap(QString, QInt) },
+  ]);
+
+  // --- Label (unchanged across v11-v20) ---------------------------------
+  QUserType.register(TYPE.LABEL, [
+    { id: Types.INT },
+    { pos: Types.VECTOR },
+    { dummy1: Types.DOUBLE },
+    { dummy2: Types.DOUBLE },
+    { size: QPair(QDouble, QDouble) },
+    { text: Types.STRING },
+    { fgColor: Types.COLOR },
+    { bgColor: Types.COLOR },
+    { pixMap: Types.PIXMAP },
+    { noScaling: Types.BOOL },
+    { showOnTop: Types.BOOL },
+  ]);
+
+  // --- Map --------------------------------------------------------------
+  const mapFields: Record<string, number>[] = [
+    { version: Types.INT },
+    { envColors: QMap(QInt, QInt) },
+    { areaNames: QMap(QInt, QString, true) },
+    { mCustomEnvColors: QMap(QInt, QColor) },
+    { mpRoomDbHashToRoomId: QMap(QString, QUInt) },
+  ];
+  if (cfg.hasMapUserData) {
+    mapFields.push({ mUserData: QMap(QString, QString) });
+  }
+  if (cfg.hasMapFont) {
+    mapFields.push(
+      { mapSymbolFont: Types.FONT },
+      { mapFontFudgeFactor: Types.DOUBLE },
+      { useOnlyMapFont: Types.BOOL }
+    );
+  }
+  mapFields.push({ areas: CONTAINER.AREAS });
+  mapFields.push(
+    cfg.modernRoomIdHash
+      ? { mRoomIdHash: QMap(QString, QInt) }
+      : { mRoomIdHash: LEGACY_TYPE.ROOM_ID }
+  );
+  mapFields.push({ labels: CONTAINER.LABELS });
+  mapFields.push({ rooms: CONTAINER.ROOMS });
+  QUserType.register(TYPE.MAP, mapFields);
+
+  registerMapModel({
+    version,
+    read: (rb) => {
+      const map = QUserType.read(rb, TYPE.MAP) as MudletMap & Record<string, unknown>;
+      // Backfill fields this version's layout doesn't carry so the canonical
+      // MudletMap is always fully populated for downstream consumers.
+      if (!cfg.hasMapUserData) map.mUserData = {};
+      if (!cfg.hasMapFont) {
+        map.mapSymbolFont = { ...DEFAULT_FONT };
+        map.mapFontFudgeFactor = 1.0;
+        map.useOnlyMapFont = false;
+      }
+      if (!cfg.modernArea) {
+        for (const value of Object.values(map.areas)) {
+          const area = value as unknown as Record<string, unknown>;
+          delete area.legacyForZUnused1;
+          delete area.legacyForZUnused2;
+          area.userData = {};
+        }
+      }
+      return map as MudletMap;
+    },
+    write: () => {
+      throw new Error(
+        `Writing Mudlet map version ${version} is not supported (read-only). ` +
+          `Mudlet only saves the latest format.`
+      );
+    },
+  });
+}

--- a/src/models/legacy.ts
+++ b/src/models/legacy.ts
@@ -48,6 +48,39 @@ const PEN_STYLE: Record<string, number> = {
   'dash dot dot line': 5,
 };
 
+// Pre-v20 maps stored custom-line keys for the standard exits in upper case
+// (N, NE, UP, ...). Mudlet lower-cases those known direction tokens while
+// loading (TRoom::restore); special-exit command keys are left untouched.
+// Downstream (e.g. json-export) indexes custom lines by these lower-case short
+// names, so legacy maps must be normalized the same way or their custom lines
+// lose their color/style/arrow on export.
+const LEGACY_DIRECTION_KEYS: Record<string, string> = {
+  N: 'n',
+  E: 'e',
+  S: 's',
+  W: 'w',
+  UP: 'up',
+  DOWN: 'down',
+  NE: 'ne',
+  SE: 'se',
+  SW: 'sw',
+  NW: 'nw',
+  IN: 'in',
+  OUT: 'out',
+};
+
+/** Userdata key Mudlet uses to carry the real symbol of a pre-v19 room. */
+const FALLBACK_SYMBOL_KEY = 'system.fallback_symbol';
+
+/** Lower-case known direction keys, mirroring Mudlet's legacy custom-line load. */
+function normalizeDirectionKeys<T>(record: Record<string, T>): Record<string, T> {
+  const out: Record<string, T> = {};
+  for (const key of Object.keys(record)) {
+    out[LEGACY_DIRECTION_KEYS[key] ?? key] = record[key];
+  }
+  return out;
+}
+
 // A neutral default map symbol font for versions (v16-v18) that don't store one.
 // Mudlet itself falls back to extracting these from userData keys; we surface a
 // sane stand-in so downstream consumers (e.g. JSON export) always have a font.
@@ -341,6 +374,24 @@ export function registerLegacyMapModel(version: number): void {
           delete area.legacyForZUnused2;
           area.userData = {};
         }
+      }
+      for (const room of Object.values(map.rooms)) {
+        // v16-v18 carried the real (non-ASCII / multi-char) symbol in userData
+        // and overrode the qint8 char after reading it. Mirror that override,
+        // and `take` (remove) the key as Mudlet does.
+        if (!cfg.stringSymbol && room.userData) {
+          const fallback = room.userData[FALLBACK_SYMBOL_KEY];
+          if (typeof fallback === 'string' && fallback.length > 0) {
+            room.symbol = fallback;
+          }
+          delete room.userData[FALLBACK_SYMBOL_KEY];
+        }
+        // Lower-case the legacy upper-case direction keys so all four
+        // custom-line maps line up with how consumers index them.
+        room.customLines = normalizeDirectionKeys(room.customLines);
+        room.customLinesArrow = normalizeDirectionKeys(room.customLinesArrow);
+        room.customLinesColor = normalizeDirectionKeys(room.customLinesColor);
+        room.customLinesStyle = normalizeDirectionKeys(room.customLinesStyle);
       }
       return map as MudletMap;
     },

--- a/src/models/mudlet-models.ts
+++ b/src/models/mudlet-models.ts
@@ -2,6 +2,10 @@ import { QUserType } from 'qtdatastream-web/types';
 
 // Importing a version module registers its types and its MapModel as a side
 // effect. Add new versions here.
+import './v16';
+import './v17';
+import './v18';
+import './v19';
 import './v20';
 
 export { getMapModel, getSupportedVersions, registerMapModel } from './model-registry';

--- a/src/models/v16.ts
+++ b/src/models/v16.ts
@@ -1,0 +1,5 @@
+import { registerLegacyMapModel } from './legacy';
+
+// Mudlet map format, version 16 (read-only). See legacy.ts for the per-version
+// layout deltas relative to v20.
+registerLegacyMapModel(16);

--- a/src/models/v17.ts
+++ b/src/models/v17.ts
@@ -1,0 +1,5 @@
+import { registerLegacyMapModel } from './legacy';
+
+// Mudlet map format, version 17 (read-only). See legacy.ts for the per-version
+// layout deltas relative to v20.
+registerLegacyMapModel(17);

--- a/src/models/v18.ts
+++ b/src/models/v18.ts
@@ -1,0 +1,5 @@
+import { registerLegacyMapModel } from './legacy';
+
+// Mudlet map format, version 18 (read-only). See legacy.ts for the per-version
+// layout deltas relative to v20.
+registerLegacyMapModel(18);

--- a/src/models/v19.ts
+++ b/src/models/v19.ts
@@ -1,0 +1,5 @@
+import { registerLegacyMapModel } from './legacy';
+
+// Mudlet map format, version 19 (read-only). See legacy.ts for the per-version
+// layout deltas relative to v20.
+registerLegacyMapModel(19);

--- a/test/legacy-versions.test.ts
+++ b/test/legacy-versions.test.ts
@@ -268,4 +268,25 @@ describe('legacy map versions 16-19', () => {
     // writeMapToBuffer dispatches on map.version; legacy models refuse to write.
     expect(() => writeMapToBuffer(map)).toThrow(/version 18 is not supported/);
   });
+
+  test('a v16 map can be upgraded to v20 by re-stamping version, then written', () => {
+    // Reading backfills every field the v20 writer needs, so flipping the
+    // version is enough to persist a legacy map in the modern format.
+    const map = readMapFromBuffer(buildMap(VERSION_OPTS[16], true));
+    expect(map.version).toBe(16);
+
+    map.version = 20; // opt in to the v20 writer
+    const reread = readMapFromBuffer(writeMapToBuffer(map));
+
+    expect(reread.version).toBe(20);
+    // Area survived the upgrade.
+    expect(reread.areas[1].rooms).toEqual([100]);
+    // Room + the converted legacy fields survived (symbol char, colour, style).
+    const room = reread.rooms[100];
+    expect(room.symbol).toBe('@');
+    expect(room.customLinesColor.n).toMatchObject({ r: 255, g: 128, b: 0 });
+    expect(room.customLinesStyle.n).toBe(2);
+    expect(room.customLines.n).toEqual([[1, 2]]);
+    expect(room.customLinesArrow.n).toBe(true);
+  });
 });

--- a/test/legacy-versions.test.ts
+++ b/test/legacy-versions.test.ts
@@ -1,0 +1,229 @@
+import { describe, test, expect } from 'vitest';
+import { QInt, QUInt, QDouble, QBool } from 'qtdatastream-web/types';
+import { concat, fromInt8 } from 'qtdatastream-web/bytes';
+import { readMapFromBuffer, writeMapToBuffer } from '../src/map-operations';
+import { getSupportedVersions } from '../src/models/mudlet-models';
+import { QString, QFont } from '../src/models/qstream-types';
+import type { MudletFont } from '../src/types';
+
+// These tests hand-serialize minimal Mudlet map buffers for versions 16-19,
+// following the exact field order/types of Mudlet's C++ TMap::restore /
+// TArea operator>> / TRoom::restore. They serve as an independent oracle for
+// the readers registered in src/models/v16..v19 (built from legacy.ts).
+
+// --- Low-level serialization helpers (Qt QDataStream big-endian) -----------
+const i = (n: number) => QInt.from(n).toBuffer();
+const u = (n: number) => QUInt.from(n).toBuffer();
+const d = (n: number) => QDouble.from(n).toBuffer();
+const b = (v: boolean) => QBool.from(v).toBuffer();
+const s = (str: string) => QString.from(str).toBuffer();
+const vec3 = (x: number, y: number, z: number) => concat([d(x), d(y), d(z)]);
+
+/** A Qt container/map count prefix followed by already-serialized entries. */
+const sized = (count: number, ...parts: Uint8Array[]) => concat([u(count), ...parts]);
+const emptyMap = () => u(0);
+
+const TEST_FONT: MudletFont = {
+  family: 'Ubuntu Mono',
+  style: '',
+  pointSize: 12,
+  pixelSize: -1,
+  styleHint: 5,
+  styleStrategy: 0,
+  weight: 50,
+  fontBits: 0,
+  stretch: 0,
+  extendedFontBits: 0,
+  letterSpacing: 0,
+  wordSpacing: 0,
+  hintingPreference: 0,
+  capital: 0,
+  styleSetting: false,
+  underline: false,
+  overline: false,
+  strikeOut: false,
+  fixedPitch: true,
+  kerning: false,
+  styleOblique: false,
+  ignorePitch: false,
+  letterSpacingIsAbsolute: false,
+};
+
+interface BuildOpts {
+  version: number;
+  hasMapUserData: boolean;
+  hasMapFont: boolean;
+  modernRoomIdHash: boolean;
+  modernArea: boolean;
+  stringSymbol: boolean;
+}
+
+/** Serialize one area (id 1, containing room 100) per this version's layout. */
+function serializeArea(opts: BuildOpts): Uint8Array {
+  const parts: Uint8Array[] = [
+    i(1), // areaId (read by the AREAS container)
+    sized(1, u(100)), // rooms: QList<uint> = [100]
+    sized(1, i(0)), // zLevels: QList<int> = [0]
+    emptyMap(), // mAreaExits: QMultiMap = {}
+    b(false), // gridMode
+    i(5), // max_x
+    i(6), // max_y
+    i(0), // max_z
+    i(-5), // min_x
+    i(-6), // min_y
+    i(0), // min_z
+    vec3(0, 0, 0), // span
+  ];
+  if (opts.modernArea) {
+    parts.push(emptyMap(), emptyMap(), emptyMap(), emptyMap()); // xmax/ymax/xmin/ymin ForZ
+  } else {
+    // v16: two unused QMap<int,int> blocks interleaved between the extents.
+    parts.push(emptyMap(), emptyMap(), emptyMap(), emptyMap(), emptyMap(), emptyMap());
+  }
+  parts.push(vec3(0, 0, 0), b(false), i(0)); // pos, isZone, zoneAreaRef
+  if (opts.modernArea) {
+    parts.push(emptyMap()); // area userData
+  }
+  return concat(parts);
+}
+
+/** Serialize one room (id 100) per this version's layout. */
+function serializeRoom(opts: BuildOpts): Uint8Array {
+  const parts: Uint8Array[] = [
+    i(100), // room id (read by the ROOMS container loop)
+    i(1), // area
+    i(2), // x
+    i(3), // y
+    i(0), // z
+    i(0), // north
+    i(0), // northeast
+    i(0), // east
+    i(0), // southeast
+    i(0), // south
+    i(0), // southwest
+    i(0), // west
+    i(0), // northwest
+    i(0), // up
+    i(0), // down
+    i(0), // in
+    i(0), // out
+    i(1), // environment
+    i(1), // weight
+    s('Test Room'), // name
+    b(false), // isLocked
+    emptyMap(), // rawSpecialExits: QMultiMap = {}
+  ];
+  // symbol: qint8 char code (v16-v18) or QString (v19+)
+  parts.push(opts.stringSymbol ? s('@') : fromInt8(64)); // 64 == '@'
+  parts.push(emptyMap()); // userData
+  parts.push(sized(1, s('n'), sized(1, concat([d(1), d(2)])))); // customLines {n:[[1,2]]}
+  parts.push(sized(1, s('n'), b(true))); // customLinesArrow {n:true}
+  // customLinesColor: pre-v20 is QMap<QString, QList<int>> = {n:[255,128,0]}
+  parts.push(sized(1, s('n'), sized(3, i(255), i(128), i(0))));
+  // customLinesStyle: pre-v20 is QMap<QString, QString> = {n:"dash line"}
+  parts.push(sized(1, s('n'), s('dash line')));
+  parts.push(emptyMap()); // exitLocks: QList<int> = []
+  parts.push(emptyMap()); // stubs: QList<int> = []
+  parts.push(emptyMap()); // exitWeights
+  parts.push(emptyMap()); // doors
+  return concat(parts);
+}
+
+/** Build a full minimal map buffer for the given legacy version. */
+function buildMap(opts: BuildOpts, withContent: boolean): Uint8Array {
+  const parts: Uint8Array[] = [
+    i(opts.version),
+    emptyMap(), // envColors
+    emptyMap(), // areaNames
+    emptyMap(), // mCustomEnvColors
+    emptyMap(), // mpRoomDbHashToRoomId
+  ];
+  if (opts.hasMapUserData) parts.push(emptyMap());
+  if (opts.hasMapFont) {
+    parts.push(QFont.from(TEST_FONT).toBuffer(), d(1.5), b(true)); // font, fudge, onlyMapFont
+  }
+  // areas container: int count, then each area
+  parts.push(withContent ? concat([i(1), serializeArea(opts)]) : i(0));
+  // mRoomIdHash: QMap (v18+) or a single legacy int (v16-v17)
+  parts.push(opts.modernRoomIdHash ? emptyMap() : i(0));
+  // labels container: int areasWithLabelsTotal
+  parts.push(i(0));
+  // rooms: read until EOF
+  if (withContent) parts.push(serializeRoom(opts));
+  return concat(parts);
+}
+
+const VERSION_OPTS: Record<number, BuildOpts> = {
+  16: { version: 16, hasMapUserData: false, hasMapFont: false, modernRoomIdHash: false, modernArea: false, stringSymbol: false },
+  17: { version: 17, hasMapUserData: true, hasMapFont: false, modernRoomIdHash: false, modernArea: true, stringSymbol: false },
+  18: { version: 18, hasMapUserData: true, hasMapFont: false, modernRoomIdHash: true, modernArea: true, stringSymbol: false },
+  19: { version: 19, hasMapUserData: true, hasMapFont: true, modernRoomIdHash: true, modernArea: true, stringSymbol: true },
+};
+
+describe('legacy map versions 16-19', () => {
+  test('all of 16-19 (and 20) are registered as supported', () => {
+    expect(getSupportedVersions()).toEqual(expect.arrayContaining([16, 17, 18, 19, 20]));
+  });
+
+  for (const version of [16, 17, 18, 19]) {
+    const opts = VERSION_OPTS[version];
+
+    test(`v${version}: reads a minimal empty map`, () => {
+      const map = readMapFromBuffer(buildMap(opts, false));
+      expect(map.version).toBe(version);
+      expect(map.areas).toEqual({});
+      expect(map.rooms).toEqual({});
+      // Fields the on-disk layout doesn't carry are backfilled to canonical defaults.
+      expect(map.mUserData).toEqual({});
+      expect(typeof map.mapSymbolFont.family).toBe('string');
+      expect(typeof map.mapFontFudgeFactor).toBe('number');
+      expect(typeof map.useOnlyMapFont).toBe('boolean');
+    });
+
+    test(`v${version}: reads an area + room with version-specific fields`, () => {
+      const map = readMapFromBuffer(buildMap(opts, true));
+
+      // Area parsed correctly, including the v16 6-map extent layout.
+      const area = map.areas[1];
+      expect(area).toBeDefined();
+      expect(area.rooms).toEqual([100]);
+      expect(area.max_x).toBe(5);
+      expect(area.min_x).toBe(-5);
+      expect(area.userData).toEqual({});
+      // The v16 unused dummy maps must not leak onto the model.
+      expect(area).not.toHaveProperty('legacyForZUnused1');
+      expect(area).not.toHaveProperty('legacyForZUnused2');
+
+      // Room parsed correctly.
+      const room = map.rooms[100];
+      expect(room).toBeDefined();
+      expect(room.name).toBe('Test Room');
+      expect(room.x).toBe(2);
+      expect(room.environment).toBe(1);
+
+      // symbol: '@' from either a byte (v16-18) or a QString (v19).
+      expect(room.symbol).toBe('@');
+
+      // customLinesColor: parsed from a QList<int> [255,128,0] into a MudletColor.
+      expect(room.customLinesColor.n).toMatchObject({ r: 255, g: 128, b: 0 });
+      // customLinesStyle: "dash line" maps to Qt::DashLine (2).
+      expect(room.customLinesStyle.n).toBe(2);
+      // unchanged-format custom-line fields round-trip as before.
+      expect(room.customLines.n).toEqual([[1, 2]]);
+      expect(room.customLinesArrow.n).toBe(true);
+    });
+  }
+
+  test('v19 reads the stored map symbol font and fudge factor', () => {
+    const map = readMapFromBuffer(buildMap(VERSION_OPTS[19], false));
+    expect(map.mapSymbolFont.family).toBe('Ubuntu Mono');
+    expect(map.mapFontFudgeFactor).toBeCloseTo(1.5);
+    expect(map.useOnlyMapFont).toBe(true);
+  });
+
+  test('writing a legacy version is rejected with a clear error', () => {
+    const map = readMapFromBuffer(buildMap(VERSION_OPTS[18], false));
+    // writeMapToBuffer dispatches on map.version; legacy models refuse to write.
+    expect(() => writeMapToBuffer(map)).toThrow(/version 18 is not supported/);
+  });
+});

--- a/test/legacy-versions.test.ts
+++ b/test/legacy-versions.test.ts
@@ -87,8 +87,22 @@ function serializeArea(opts: BuildOpts): Uint8Array {
   return concat(parts);
 }
 
+interface RoomExtras {
+  /** Direction key the custom lines are stored under (default lower-case 'n'). */
+  lineKey?: string;
+  /** userData entries (e.g. a legacy symbol fallback). */
+  userData?: [string, string][];
+}
+
+/** Serialize a QMap<QString,QString> from key/value pairs. */
+function strMap(entries: [string, string][]): Uint8Array {
+  if (entries.length === 0) return emptyMap();
+  return sized(entries.length, ...entries.flatMap(([k, v]) => [s(k), s(v)]));
+}
+
 /** Serialize one room (id 100) per this version's layout. */
-function serializeRoom(opts: BuildOpts): Uint8Array {
+function serializeRoom(opts: BuildOpts, extras: RoomExtras = {}): Uint8Array {
+  const lineKey = extras.lineKey ?? 'n';
   const parts: Uint8Array[] = [
     i(100), // room id (read by the ROOMS container loop)
     i(1), // area
@@ -115,13 +129,13 @@ function serializeRoom(opts: BuildOpts): Uint8Array {
   ];
   // symbol: qint8 char code (v16-v18) or QString (v19+)
   parts.push(opts.stringSymbol ? s('@') : fromInt8(64)); // 64 == '@'
-  parts.push(emptyMap()); // userData
-  parts.push(sized(1, s('n'), sized(1, concat([d(1), d(2)])))); // customLines {n:[[1,2]]}
-  parts.push(sized(1, s('n'), b(true))); // customLinesArrow {n:true}
-  // customLinesColor: pre-v20 is QMap<QString, QList<int>> = {n:[255,128,0]}
-  parts.push(sized(1, s('n'), sized(3, i(255), i(128), i(0))));
-  // customLinesStyle: pre-v20 is QMap<QString, QString> = {n:"dash line"}
-  parts.push(sized(1, s('n'), s('dash line')));
+  parts.push(strMap(extras.userData ?? [])); // userData
+  parts.push(sized(1, s(lineKey), sized(1, concat([d(1), d(2)])))); // customLines {key:[[1,2]]}
+  parts.push(sized(1, s(lineKey), b(true))); // customLinesArrow {key:true}
+  // customLinesColor: pre-v20 is QMap<QString, QList<int>> = {key:[255,128,0]}
+  parts.push(sized(1, s(lineKey), sized(3, i(255), i(128), i(0))));
+  // customLinesStyle: pre-v20 is QMap<QString, QString> = {key:"dash line"}
+  parts.push(sized(1, s(lineKey), s('dash line')));
   parts.push(emptyMap()); // exitLocks: QList<int> = []
   parts.push(emptyMap()); // stubs: QList<int> = []
   parts.push(emptyMap()); // exitWeights
@@ -130,7 +144,7 @@ function serializeRoom(opts: BuildOpts): Uint8Array {
 }
 
 /** Build a full minimal map buffer for the given legacy version. */
-function buildMap(opts: BuildOpts, withContent: boolean): Uint8Array {
+function buildMap(opts: BuildOpts, withContent: boolean, roomExtras: RoomExtras = {}): Uint8Array {
   const parts: Uint8Array[] = [
     i(opts.version),
     emptyMap(), // envColors
@@ -149,7 +163,7 @@ function buildMap(opts: BuildOpts, withContent: boolean): Uint8Array {
   // labels container: int areasWithLabelsTotal
   parts.push(i(0));
   // rooms: read until EOF
-  if (withContent) parts.push(serializeRoom(opts));
+  if (withContent) parts.push(serializeRoom(opts, roomExtras));
   return concat(parts);
 }
 
@@ -211,6 +225,34 @@ describe('legacy map versions 16-19', () => {
       // unchanged-format custom-line fields round-trip as before.
       expect(room.customLines.n).toEqual([[1, 2]]);
       expect(room.customLinesArrow.n).toBe(true);
+    });
+  }
+
+  for (const version of [16, 17, 18]) {
+    test(`v${version}: room symbol falls back to userData["system.fallback_symbol"]`, () => {
+      // A non-ASCII / multi-char symbol can't fit in the legacy qint8, so Mudlet
+      // stashed it in userData and overrode the byte after the fact.
+      const map = readMapFromBuffer(
+        buildMap(VERSION_OPTS[version], true, { userData: [['system.fallback_symbol', '☠']] })
+      );
+      const room = map.rooms[100];
+      expect(room.symbol).toBe('☠');
+      // The fallback key is consumed (taken), not left to leak into export.
+      expect(room.userData).not.toHaveProperty('system.fallback_symbol');
+    });
+  }
+
+  for (const version of [16, 17, 18, 19]) {
+    test(`v${version}: legacy upper-case custom-line direction keys are lower-cased`, () => {
+      const map = readMapFromBuffer(buildMap(VERSION_OPTS[version], true, { lineKey: 'NE' }));
+      const room = map.rooms[100];
+      // 'NE' must be normalized to 'ne' across all four custom-line maps so the
+      // JSON/reader exports (which index by lower-case short names) find them.
+      expect(room.customLines.ne).toEqual([[1, 2]]);
+      expect(room.customLinesArrow.ne).toBe(true);
+      expect(room.customLinesColor.ne).toMatchObject({ r: 255, g: 128, b: 0 });
+      expect(room.customLinesStyle.ne).toBe(2);
+      expect(room.customLines).not.toHaveProperty('NE');
     });
   }
 

--- a/test/map-operations.test.ts
+++ b/test/map-operations.test.ts
@@ -113,13 +113,13 @@ describe('map version dispatch', () => {
 
   test('throws a clear error for an unsupported map version', () => {
     // writeBuffer always emits v20; the version is the leading big-endian
-    // int32, so bytes 0..3 are [0, 0, 0, 20]. Patch it to 16 to simulate an
-    // older map without needing a real v16 fixture.
+    // int32, so bytes 0..3 are [0, 0, 0, 20]. Patch it to 15 (below the
+    // oldest supported version) to simulate an unsupported map.
     const buf = MudletMapReader.writeBuffer(makeMinimalMap()).slice();
     expect([buf[0], buf[1], buf[2], buf[3]]).toEqual([0, 0, 0, 20]);
-    buf[3] = 16;
+    buf[3] = 15;
 
-    expect(() => readMapFromBuffer(buf)).toThrow(/Unsupported Mudlet map version 16/);
+    expect(() => readMapFromBuffer(buf)).toThrow(/Unsupported Mudlet map version 15/);
   });
 });
 


### PR DESCRIPTION
Mudlet's binary map format changed over time; previously only v20 could
be parsed. This adds read-only models for v16 through v19, dispatched by
the leading version int just like v20.

The version deltas mirror Mudlet's C++ TMap::restore / TArea operator>> /
TRoom::restore version gating exactly:
  * map-level mUserData      : v17+ (absent in v16)
  * map symbol font fields   : v19+ (absent in v16-v18)
  * mRoomIdHash              : QMap in v18+, single legacy int in v16-v17
  * area per-Z extent maps   : 4 in v17+, 6 (2 unused) in v16; area
                               userData absent in v16
  * room.symbol              : QString in v19+, single qint8 char in v16-v18
  * room.customLinesColor    : QColor in v20, QList<int> RGB in v16-v19
  * room.customLinesStyle    : QUInt in v20, QString style-name in v16-v19

A shared builder (legacy.ts) registers a read-only model per version from
a small config of these deltas; v16..v19 modules just invoke it. Writing
older versions is intentionally rejected (Mudlet only ever saves the
newest format), and version-only fields are backfilled to canonical
defaults so downstream consumers always see a fully-populated MudletMap.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01HZKwqyYWqAiTLTduMHzMwS